### PR TITLE
Fix builder-bob dep for npm by specifying version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "prettier": "^2.0.5",
     "react": "16.13.1",
     "react-native": "0.63.4",
-    "react-native-builder-bob": "^",
+    "react-native-builder-bob": "^0.18",
     "react-native-gesture-handler": "1.8.0",
     "react-native-reanimated": "2.0.0-rc.0",
     "release-it": "^14.2.2",


### PR DESCRIPTION
## Description

AFAICT, npm (v7.6.0) does not accept versions specified as only `"^"`. npm requires a version number.

```
npm ERR! npm ERR! Invalid tag name "^": Tags may not have any characters that encodeURIComponent encodes.
```
